### PR TITLE
chore: mention REUSE tool in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Gigya Services (GS) Java SDK 
+
+[![REUSE status](https://api.reuse.software/badge/github.com/SAP/gigya-java-sdk)](https://api.reuse.software/info/github.com/SAP/gigya-java-sdk)
+
 Documentation: http://developers.gigya.com/display/GD/Java
 
 ## Description
@@ -35,3 +38,6 @@ Via pull request to this repository.
 
 ## To-Do (upcoming changes)
 None
+
+## Licensing
+Copyright 2020-2021 SAP SE or an SAP affiliate company and gigya-java-sdk contributors. Please see our [LICENSE](LICENSE.txt) for copyright and license information. Detailed information including third-party components and their licensing/copyright information is available [via the REUSE tool](https://api.reuse.software/info/github.com/SAP/gigya-java-sdk).


### PR DESCRIPTION
In line with SAP OSPO requirements, this PR adds the REUSE Tool links to the README

**Notes:** 
- Please register the repository with the REUSE Tool to complete the integration (see #14 and #15)

Fixes #9
Fixes #11